### PR TITLE
Make hnmp.Table._rows an OrderedDict if possible (Python 2.7+)

### DIFF
--- a/hnmp.py
+++ b/hnmp.py
@@ -322,7 +322,14 @@ class Table(object):
     def __init__(self, columns=None, column_value_mapping=None):
         self._column_aliases = {} if columns is None else columns
         self._column_value_mapping = {} if column_value_mapping is None else column_value_mapping
-        self._rows = {}
+
+        # OrderedDict() preserves order as returned by SNMP agent but it is only 
+        # available since Python 2.7
+        try:
+            import collections
+            self._rows = collections.OrderedDict()
+        except ImportError:
+            self._rows = {}
 
     def _add_value(self, raw_column, row_id, value):
         column = self._column_aliases.get(raw_column, raw_column)


### PR DESCRIPTION
This change ensures that ```SNMP.table.columns``` are in the same order as returned by the SNMP query. The difference is shown below:

Without OrderedDict:

```python
>>> ifEntry = '1.3.6.1.2.1.2.2.1'
>>> snmp.table(ifEntry).columns[1]
(11, 13, 12, 16, 18, 1, 3, 2, 5, 4, 7, 6, 9, 8)
```

With OrderedDict:

```python
>>> snmp.table(ifEntry).columns[1]
(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 16, 18)
```