### PR TITLE
Added SNMP.rows() method.

### DIFF
--- a/hnmp.py
+++ b/hnmp.py
@@ -313,6 +313,18 @@ class SNMP(object):
 
         return t
 
+    def rows(self, *args, **kwargs):
+        """
+        Return table as list of rows where each row is a tuple of columns.
+
+        ``SNMP.rows()`` takes the same arguments as ``SNMP.table()``.
+
+        """
+
+        table = self.table(*args, **kwargs)
+        rows = zip(*table.columns.values())
+        return rows
+
 
 class SNMPError(Exception):
     pass


### PR DESCRIPTION
The ```SNMP.rows()``` method is a wrapper for the ```SNMP.table()``` method which re-arranges and returns the ```SNMP.table.columns``` as a list of rows. Each row contains a tuple of columns. ```SNMP.rows()``` takes the same arguments as ```SNMP.table()```.

```python
>>> ifEntry = ' 	1.3.6.1.2.1.2.2.1'
>>> snmp.rows(ifEntry)
[(1, u'GigabitEthernet0', 6, 1500, 100000000, '\x0ch\x03&\x80\xef', 2, 2, datetime.timedelta(43, 85641, 860000), 0, 0, 0, 0, 0, 60, 0, 0, 0), 
 (2, u'FastEthernet0', 6, 1500, 100000000, '\x0ch\x03&\x80\xd8', 1, 1, datetime.timedelta(0, 111, 580000), 3006733001L, 32932557, 0, 0, 0, 2156739797L, 21664124, 0, 0),
  ...]
```

```SNMP.rows()``` may not be the best name for the method. Maybe someone can come up with a better name.